### PR TITLE
template now generate full widget path

### DIFF
--- a/lib/generators/rspec/templates/widget_spec.erb
+++ b/lib/generators/rspec/templates/widget_spec.erb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe <%= class_name %>Widget do
   has_widgets do |root|
-    root << widget(:<%= class_name %>)
+    root << widget('<%= class_name.tableize.singularize %>')
   end
   
   it "should render :display" do
-    render_widget(:<%= class_name %>).should have_selector("h1")
+    render_widget('<%= class_name.tableize.singularize %>').should have_selector("h1")
   end
 end


### PR DESCRIPTION
hey nick!

I do a lot of nested widgets like:

` rails g apotomo:widget WidgetOne::SubWidget display

then the generated spec is:

has_widgets do |root|
  root << widget(:WidgetOne::SubWidget)
end

it "should render :display" do
  render_widget(:WidgetOne::SubWidget).should have_selector("h1")
end'

after this commit it generates

has_widgets do |root|
  root << widget('widget_one/subwidget')
end

it "should render :display" do
  render_widget('widget_one/subwidget').should have_selector("h1")
end

this is very simple, but for who was learning Apotomo (like me) it was a pain in the ass =P

and hey, this is my first code commit ever! yay! i don't know how to write markups :P
