### PR TITLE
Namespace tests. So for `Twitter::Tweet` it will generate `spec/widgets/...

### DIFF
--- a/lib/generators/rspec/widget_generator.rb
+++ b/lib/generators/rspec/widget_generator.rb
@@ -6,7 +6,7 @@ module Rspec
       source_root File.expand_path('../templates', __FILE__)
 
       def create_cell_spec_file
-        template "widget_spec.erb", File.join("spec/widgets/#{file_name}_widget_spec.rb")
+        template "widget_spec.erb", File.join("spec/widgets/", class_path, "#{file_name}_widget_spec.rb")
       end
     end
   end

--- a/spec/rspec-apotomo/widget_spec_generator_spec.rb
+++ b/spec/rspec-apotomo/widget_spec_generator_spec.rb
@@ -14,22 +14,22 @@ describe Rspec::Generators::WidgetGenerator do
   end
 
   it "creates widget spec" do
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /require 'spec_helper'/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /describe Twitter::TweetWidget do/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /has_widgets do |root|/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /root << widget\('twitter\/tweet'\)/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /end/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /require 'spec_helper'/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /describe Twitter::TweetWidget do/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /has_widgets do |root|/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /root << widget\('twitter\/tweet'\)/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /end/
   end
   
   it 'creates display state' do
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /it "should render :display" do/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /render_widget\('twitter\/tweet', :display\).should have_selector\("h1"\)/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /end/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /it "should render :display" do/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /render_widget\('twitter\/tweet', :display\).should have_selector\("h1"\)/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /end/
   end
   
   it 'creates form state' do
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /it "should render :form" do/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /render_widget\('twitter\/tweet', :form\).should have_selector\("h1"\)/
-    test.assert_file "spec/widgets/tweet_widget_spec.rb", /end/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /it "should render :form" do/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /render_widget\('twitter\/tweet', :form\).should have_selector\("h1"\)/
+    test.assert_file "spec/widgets/twitter/tweet_widget_spec.rb", /end/
   end
 end


### PR DESCRIPTION
Namespace tests. 

So for `Twitter::Tweet` it will generate `spec/widgets/twitter/tweet_widget_spec.rb` instead of just `spec/widgets/tweet_widget_spec.rb`
