### PR TITLE
Advise user when generator is run and capyara/webrat not available

### DIFF
--- a/lib/rspec-apotomo.rb
+++ b/lib/rspec-apotomo.rb
@@ -12,6 +12,13 @@ module RSpec
         RSpec.configure do |c|
           c.include RSpec::Rails::WidgetExampleGroup, :example_group => { :file_path => /spec\/widgets/ }
         end
+
+        unless defined?(Capybara) || defined?(Webrat)
+          puts "**************************************************************"
+          puts "rspec-apotomo's widget test requires either Capybara or Webrat" 
+          puts "Please add either gem to your gemset to remove this warning"
+          puts "**************************************************************"
+        end
       end
     end
   end


### PR DESCRIPTION
 The error without either installed is the enigmatic:

```
NoMethodError:
  undefined method `has_selector?' for #<ActiveSupport::SafeBuffer:0x000000054b1090>
```

When the generator is executed, this patch will warn the user that the default spec requires capybara/webrat installed.

I'm happy to write a test for this if you can point me in the right direction!
